### PR TITLE
feat: Open file in edit mode on double-click

### DIFF
--- a/packages/client/src/components/navigation/file-viewer-dialog.tsx
+++ b/packages/client/src/components/navigation/file-viewer-dialog.tsx
@@ -42,6 +42,7 @@ type FileViewerDialogProps = {
   onSave?: (content: string) => Promise<void> | void
   filePath?: string
   projectId?: number
+  startInEditMode?: boolean
 }
 
 function getLanguageByExtension(extension?: string): string {
@@ -89,7 +90,8 @@ export function FileViewerDialog({
   onClose,
   onSave,
   filePath,
-  projectId
+  projectId,
+  startInEditMode
 }: FileViewerDialogProps) {
   const [isEditingFile, setIsEditingFile] = useState(false)
   const [editedContent, setEditedContent] = useState<string>('')
@@ -134,8 +136,11 @@ export function FileViewerDialog({
       setActiveTab('edit')
       setSelectedHistoryVersion(null)
       setShowDiff(false)
+      if (startInEditMode && viewedFile) {
+        setIsEditingFile(true)
+      }
     }
-  }, [viewedFile, markdownText, open])
+  }, [viewedFile, markdownText, open, startInEditMode])
 
   // Handle F11 key for fullscreen toggle
   useEffect(() => {

--- a/packages/client/src/components/projects/file-panel/file-explorer/file-explorer.tsx
+++ b/packages/client/src/components/projects/file-panel/file-explorer/file-explorer.tsx
@@ -55,7 +55,11 @@ export function FileExplorer({ ref, allowSpacebarToSelect }: FileExplorerProps) 
   const project = useMemo(() => projectDataResponse?.data, [projectDataResponse])
 
   const [viewedFile, setViewedFile] = useState<ProjectFile | null>(null)
-  const closeFileViewer = () => setViewedFile(null)
+  const [startFileViewerInEditMode, setStartFileViewerInEditMode] = useState(false)
+  const closeFileViewer = () => {
+    setViewedFile(null);
+    setStartFileViewerInEditMode(false);
+  }
 
   const updateFileContentMutation = useUpdateFileContent()
 
@@ -347,7 +351,10 @@ export function FileExplorer({ ref, allowSpacebarToSelect }: FileExplorerProps) 
                     <FileTree
                       ref={ref.fileTreeRef}
                       root={fileTree}
-                      onViewFile={(file) => setViewedFile(file as ProjectFile)}
+                      onViewFile={(file: ProjectFile, editMode?: boolean) => {
+                        setViewedFile(file as ProjectFile);
+                        setStartFileViewerInEditMode(editMode || false);
+                      }}
                       projectRoot={project?.path || ''}
                       resolveImports={resolveImports}
                       preferredEditor={preferredEditor as 'vscode' | 'cursor' | 'webstorm'}
@@ -390,7 +397,10 @@ export function FileExplorer({ ref, allowSpacebarToSelect }: FileExplorerProps) 
               <FileTree
                 ref={ref.fileTreeRef}
                 root={fileTree}
-                onViewFile={(file) => setViewedFile(file as ProjectFile)}
+                onViewFile={(file: ProjectFile, editMode?: boolean) => {
+                  setViewedFile(file as ProjectFile);
+                  setStartFileViewerInEditMode(editMode || false);
+                }}
                 projectRoot={project?.path || ''}
                 resolveImports={resolveImports}
                 preferredEditor={preferredEditor as 'vscode' | 'cursor' | 'webstorm'}
@@ -423,6 +433,7 @@ export function FileExplorer({ ref, allowSpacebarToSelect }: FileExplorerProps) 
           open={!!viewedFile}
           onClose={closeFileViewer}
           projectId={selectedProjectId || undefined}
+          startInEditMode={startFileViewerInEditMode}
         />
       )}
     </div>

--- a/packages/client/src/components/projects/file-panel/file-tree/file-tree.tsx
+++ b/packages/client/src/components/projects/file-panel/file-tree/file-tree.tsx
@@ -61,7 +61,7 @@ export type VisibleItem = {
 
 export type FileTreeProps = {
   root: Record<string, FileNode>
-  onViewFile?: (file: ProjectFile | null) => void
+  onViewFile?: (file: ProjectFile | null, editMode?: boolean) => void
   projectRoot: string
   resolveImports?: boolean
   preferredEditor: EditorType
@@ -103,7 +103,7 @@ interface FileTreeNodeRowProps {
   isFocused: boolean
   onFocus: () => void
   onToggleOpen: () => void
-  onViewFile?: (file: ProjectFile) => void
+  onViewFile?: (file: ProjectFile, editMode?: boolean) => void
   projectRoot: string
   onRequestAIFileChange?: (filePath: string) => void
 }
@@ -167,7 +167,7 @@ const FileTreeNodeRow = forwardRef<HTMLDivElement, FileTreeNodeRowProps>(functio
     if (isFolder) {
       onToggleOpen()
     } else if (item.node.file && onViewFile) {
-      onViewFile(item.node.file)
+      onViewFile(item.node.file, false)
     }
   }, [isFolder, item.node.file, onToggleOpen, onViewFile])
 
@@ -205,6 +205,11 @@ const FileTreeNodeRow = forwardRef<HTMLDivElement, FileTreeNodeRowProps>(functio
           }}
           tabIndex={0}
           onClick={onFocus}
+          onDoubleClick={() => {
+            if (!isFolder && item.node.file && onViewFile) {
+              onViewFile(item.node.file, true)
+            }
+          }}
           onKeyDown={handleKeyDown}
         >
           <div className='flex items-center hover:bg-muted/50 rounded-sm gap-1 group'>


### PR DESCRIPTION
Implemented functionality to open a file in edit mode when it is double-clicked in the file tree.

Changes include:
- Modified `FileTree.tsx` to detect double-clicks on file items and trigger a new `editMode` parameter in the `onViewFile` callback.
- Updated `FileViewerDialog.tsx` to accept a `startInEditMode` prop, which, if true, will open the dialog directly in file editing mode.
- Adjusted `FileExplorer.tsx` to manage the `startInEditMode` state based on the `onViewFile` callback from the file tree and pass it to the `FileViewerDialog`.

Note: No relevant automated tests were found for the modified components. Manual testing is recommended to verify this new functionality.